### PR TITLE
Fix testing for boolean config.exclude.query

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ function setupCache (config = {}) {
   config.debug = config.debug || false
 
   config.exclude = config.exclude || {}
-  config.exclude.query = config.exclude.query || true
+  config.exclude.query = config.exclude.query !== undefined ? config.exclude.query : true
   config.exclude.paths = config.exclude.paths || []
   config.exclude.filter = config.exclude.filter || null
 


### PR DESCRIPTION
Truthiness of `config.exclude.query` at `setupCache(config)` was being ignored by the `||` pipe operator.
* Swapped that out for an explicit `undefined` check
* Added tests for queries
* Tests now point to the always-online [https://httpbin.org](https://resttesttest.com/) service