### PR TITLE
Fix transformResponse behavior

### DIFF
--- a/src/memory.js
+++ b/src/memory.js
@@ -1,5 +1,6 @@
 import size from 'lodash/size'
 import map from 'lodash/map'
+import cloneDeep from 'lodash/cloneDeep'
 
 class MemoryStore {
   constructor () {
@@ -7,7 +8,9 @@ class MemoryStore {
   }
 
   async getItem (key) {
-    return this.store[key] || null
+    const item = this.store[key] || null
+
+    return cloneDeep(item)
   }
 
   async setItem (key, value) {

--- a/src/memory.js
+++ b/src/memory.js
@@ -1,6 +1,5 @@
 import size from 'lodash/size'
 import map from 'lodash/map'
-import cloneDeep from 'lodash/cloneDeep'
 
 class MemoryStore {
   constructor () {
@@ -10,11 +9,11 @@ class MemoryStore {
   async getItem (key) {
     const item = this.store[key] || null
 
-    return cloneDeep(item)
+    return JSON.parse(item)
   }
 
   async setItem (key, value) {
-    this.store[key] = value
+    this.store[key] = JSON.stringify(value)
 
     return value
   }

--- a/test/spec/cache.spec.js
+++ b/test/spec/cache.spec.js
@@ -1,7 +1,7 @@
 /* globals describe it beforeEach */
 
 import assert from 'assert'
-import isObject from 'lodash/isObject'
+import isString from 'lodash/isString'
 import isFunction from 'lodash/isFunction'
 
 import cache from 'src/cache'
@@ -39,9 +39,12 @@ describe('Cache store', () => {
 
     assert.ok(cacheResult)
 
-    assert.ok(isObject(store.store.test))
-    assert.ok(store.store.test.data.data.youhou)
-    assert.equal(store.store.test.expires, expires)
+    assert.ok(isString(store.store.test))
+
+    const storedData = JSON.parse(store.store.test)
+
+    assert.equal(storedData.expires, expires)
+    assert.ok(storedData.data.data.youhou)
 
     store.setItem = async () => {
       throw new Error('Faking store error')

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -206,18 +206,18 @@ describe('Integration', function () {
     assert.deepEqual(cache.store, store)
   })
 
-  it('Should not transform response data when response comes from cache', async function () {
+  it('Should be able to transform response whether it comes from network or cache', async function () {
     this.timeout(REQUEST_TIMEOUT)
 
     const api5 = setup()
 
     const request = () => api5({
       url: 'https://httpbin.org/get?a=foo&b=bar',
-      transformResponse: api.defaults.transformResponse.concat([
+      transformResponse: [
         (data, header) => {
           return data.args.a + data.args.b
         }
-      ]),
+      ],
       cache: {
         exclude: {
           query: false
@@ -226,15 +226,29 @@ describe('Integration', function () {
     })
 
     let response = await request()
+    let response2 = await request()
+    let response3 = await request()
 
     assert.ok(!response.request.fromCache)
     assert.equal(response.data, 'foobar')
 
-    assert.doesNotThrow(async () => {
-      response = await request()
-      assert.ok(response.request.fromCache)
-      assert.equal(response.data, 'foobar')
-    })
+    assert.ok(response2.request.fromCache)
+    assert.equal(response2.data, 'foobar')
+
+    assert.ok(response3.request.fromCache)
+    assert.equal(response3.data, 'foobar')
+
+    // assert.doesNotThrow(async () => {
+    //   response = await request()
+    //   assert.ok(response.request.fromCache)
+    //   assert.equal(response.data, 'foobar')
+
+    //   assert.doesNotThrow(async () => {
+    //     response = await request()
+    //     assert.ok(response.request.fromCache)
+    //     assert.equal(response.data, 'foobar')
+    //   })
+    // })
   })
 
   // Helpers

--- a/test/spec/memory.spec.js
+++ b/test/spec/memory.spec.js
@@ -15,7 +15,7 @@ describe('Memory store', () => {
   it('getItem(): Should retrieve an item', async () => {
     const expected = 'bar'
 
-    store.store.foo = expected
+    store.store.foo = JSON.stringify(expected)
 
     const value = await store.getItem('foo')
 
@@ -27,7 +27,7 @@ describe('Memory store', () => {
 
     await store.setItem('foo', expected)
 
-    assert.equal(store.store.foo, expected)
+    assert.equal(store.store.foo, JSON.stringify(expected))
   })
 
   it('removeItem(): Should remove an item', async () => {
@@ -48,5 +48,19 @@ describe('Memory store', () => {
     assert.equal(store.store.hello, undefined)
 
     assert.ok(isEmpty(store.store))
+  })
+
+  it('Should serialize stored data to prevent modification by reference', async () => {
+    const data = {
+      key: 'value'
+    }
+
+    await store.setItem('key', data)
+
+    data.key = 'other value'
+
+    const storedData = await store.getItem('key')
+
+    assert.notEqual(data.key, storedData.key)
   })
 })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,7 @@ const dependencies = [
   'lodash/isEmpty',
   'lodash/isString',
   'lodash/isFunction',
+  'lodash/cloneDeep',
   'lodash/size',
   'lodash/find',
   'lodash/map',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,6 @@ const dependencies = [
   'lodash/isEmpty',
   'lodash/isString',
   'lodash/isFunction',
-  'lodash/cloneDeep',
   'lodash/size',
   'lodash/find',
   'lodash/map',


### PR DESCRIPTION
Fixes #28 

The issue I noticed was that the stored data was modified by the axios `transformResponse` method through an object reference.
Due to this, event though the response was not re-written to cache the object stored in cache was being modified by the `transformResponse` method.