### PR TITLE
Add runkit example

### DIFF
--- a/examples/basic.js
+++ b/examples/basic.js
@@ -1,0 +1,32 @@
+const {setup} = require('axios-cache-adapter')
+
+// Create an `axios` instance with `axios-cache-adapter` pre-configured
+const api = setup({
+    // `axios` options
+    baseURL: 'https://httpbin.org',
+
+    // `axios-cache-adapter` options
+    cache: {
+        // Cache expiration in milliseconds, here 15min
+        maxAge: 15 * 60 * 1000,
+        // Cache exclusion rules
+        exclude: {
+            // Store responses from requests with query parameters in cache
+            query: false
+        }
+    }
+})
+
+// Make a request to https://httpbin.org/get?foo=bar
+const response = await api.get('/get?foo=bar')
+
+// Check recieved data and that response did not come from cache
+console.log(response.data.args.foo)
+console.log(response.request.fromCache === true)
+
+// Make another request to the same endpoint
+const anotherResponse = await api.get('/get?foo=bar')
+
+// Check recieved data and that response came from the cache
+console.log(anotherResponse.data.args.foo)
+console.log(anotherResponse.request.fromCache === true)

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "main": "dist/cache.node.js",
   "browser": "dist/cache.js",
+  "runkitExampleFilename": "examples/basic.js",
   "keywords": [
     "axios",
     "cache",


### PR DESCRIPTION
Will inject the content of `examples/basic.js` to the [runkit page](https://npm.runkit.com/axios-cache-adapter) of `axios-cache-adapter`