### PR TITLE
Don't check for stale cache when offline

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -45,7 +45,9 @@ async function read (config, req) {
 
   const { expires, data } = entry
 
-  if (expires !== 0 && (expires < Date.now())) {
+  // Do not check for stale cache if offline
+  const offline = 'onLine' in navigator && !navigator.onLine;
+  if (!offline && expires !== 0 && (expires < Date.now())) {
     config.debug('cache-stale', req.url)
     const error = new Error()
 


### PR DESCRIPTION
In case user is offline, we should not throw an cache reading error