### PR TITLE
Fix query inclusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bower_components
 coverage
 package-lock.json
 .vscode
+yarn.lock

--- a/src/exclude.js
+++ b/src/exclude.js
@@ -11,7 +11,9 @@ function exclude (config = {}, req) {
   }
 
   // do not cache request with query
-  const hasQueryParams = req.url.match(/\?.*$/) || !isEmpty(req.params)
+  const hasQueryParams = req.url.match(/\?.*$/) ||
+    !isEmpty(req.params) ||
+    (typeof URLSearchParams !== 'undefined' && req.params instanceof URLSearchParams)
 
   if (exclude.query && hasQueryParams) {
     debug(`Excluding request by query ${req.url}`)

--- a/test/spec/exclude.spec.js
+++ b/test/spec/exclude.spec.js
@@ -6,8 +6,8 @@ import exclude from 'src/exclude'
 
 describe('Cache exclusion', () => {
   const url = 'https://some-rest.api/users'
-  const debug = () => {}
-  // const debug = (...args) => { console.log(...args) }
+  // const debug = () => {}
+  const debug = (...args) => { console.log(...args) }
 
   it('Should not exclude if not configured', () => {
     const config = { debug }
@@ -15,7 +15,7 @@ describe('Cache exclusion', () => {
     assert.equal(exclude(config, { url }), false)
   })
 
-  it('Should exclude requests with query parameters', () => {
+  it('Should exclude requests with query parameters with config.exclude.query=true', () => {
     const config = {
       exclude: { query: true },
       debug
@@ -26,6 +26,19 @@ describe('Cache exclusion', () => {
 
     assert.ok(exclude(config, reqWithQuery))
     assert.ok(exclude(config, reqWithParams))
+  })
+
+  it('Should not exclude requests with query parameters with config.exclude.query=false', () => {
+    const config = {
+      exclude: { query: false },
+      debug
+    }
+
+    const reqWithQuery = { url: `${url}?with=query&params=42` }
+    const reqWithParams = { url, params: { with: 'query', params: 42 } }
+
+    assert.ok(!exclude(config, reqWithQuery))
+    assert.ok(!exclude(config, reqWithParams))
   })
 
   it('Should exclude requests that match paths', () => {

--- a/test/spec/exclude.spec.js
+++ b/test/spec/exclude.spec.js
@@ -6,8 +6,8 @@ import exclude from 'src/exclude'
 
 describe('Cache exclusion', () => {
   const url = 'https://some-rest.api/users'
-  // const debug = () => {}
-  const debug = (...args) => { console.log(...args) }
+  const debug = () => {}
+  // const debug = (...args) => { console.log(...args) }
 
   it('Should not exclude if not configured', () => {
     const config = { debug }
@@ -23,9 +23,11 @@ describe('Cache exclusion', () => {
 
     const reqWithQuery = { url: `${url}?with=query&params=42` }
     const reqWithParams = { url, params: { with: 'query', params: 42 } }
+    const reqWithSearchParams = { url, params: new URLSearchParams('with=query&params=42') }
 
     assert.ok(exclude(config, reqWithQuery))
     assert.ok(exclude(config, reqWithParams))
+    assert.ok(exclude(config, reqWithSearchParams))
   })
 
   it('Should not exclude requests with query parameters with config.exclude.query=false', () => {
@@ -36,9 +38,11 @@ describe('Cache exclusion', () => {
 
     const reqWithQuery = { url: `${url}?with=query&params=42` }
     const reqWithParams = { url, params: { with: 'query', params: 42 } }
+    const reqWithSearchParams = { url, params: new URLSearchParams('with=query&params=42') }
 
     assert.ok(!exclude(config, reqWithQuery))
     assert.ok(!exclude(config, reqWithParams))
+    assert.ok(!exclude(config, reqWithSearchParams))
   })
 
   it('Should exclude requests that match paths', () => {

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -130,6 +130,36 @@ describe('Integration', function () {
     assert.ok(response.request.fromCache)
   })
 
+  it('Should cache GET requests with params even though URLSearchParams does not exist', async () => {
+    const URLSearchParamsBackup = URLSearchParams
+    window.URLSearchParams = undefined
+
+    const api = setup({
+      cache: {
+        exclude: { query: false }
+      }
+    })
+
+    const definition = {
+      url: 'https://httpbin.org/get',
+      params: { userId: 42 },
+      method: 'get'
+    }
+
+    let response = await api(definition)
+
+    assert.equal(response.status, 200)
+    assert.ok(has(response.data.args, 'userId'))
+    assert.ok(!response.request.fromCache)
+
+    response = await api(definition)
+
+    assert.ok(has(response.data.args, 'userId'))
+    assert.ok(response.request.fromCache)
+
+    window.URLSearchParams = URLSearchParamsBackup
+  })
+
   it('Should apply a cache size limit', async function () {
     this.timeout(REQUEST_TIMEOUT)
 

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -104,19 +104,19 @@ describe('Integration', function () {
       url: 'https://httpbin.org/get?userId=2',
       method: 'get'
     }
-    // const definitionWithParams = {
-    //   url: 'https://httpbin.org/get',
-    //   params: { userId: 2 },
-    //   method: 'get'
-    // }
+    const definitionWithParams = {
+      url: 'https://httpbin.org/get',
+      params: { userId: 2 },
+      method: 'get'
+    }
 
-    let response = await api2(definition)
+    let response = await api2(definitionWithParams)
 
     assert.equal(response.status, 200)
     assert.ok(isObject(response.data))
     assert.ok(has(response.data.args, 'userId'))
 
-    response = await api2(definition)
+    response = await api2(definitionWithParams)
 
     assert.ok(has(response.data.args, 'userId'))
     assert.ok(response.request.fromCache)

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -110,11 +110,19 @@ describe('Integration', function () {
       method: 'get'
     }
 
-    let response = await api2(definitionWithParams)
+    let response = await api2(definition)
 
     assert.equal(response.status, 200)
     assert.ok(isObject(response.data))
     assert.ok(has(response.data.args, 'userId'))
+    assert.ok(!response.request.fromCache)
+
+    response = await api2(definitionWithParams)
+
+    assert.ok(has(response.data.args, 'userId'))
+    assert.ok(response.request.fromCache)
+
+    definitionWithParams.params = new URLSearchParams('userId=2')
 
     response = await api2(definitionWithParams)
 


### PR DESCRIPTION
Fixes #31 

Serializes axios `params` option into cache key by default. Handles `URLSearchParams` correctly.