### PR TITLE
Make serializeQuery publicly available

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -108,5 +108,5 @@ function serializeQuery (req) {
   return `?${req.params.toString()}`
 }
 
-export { read, write, key, invalidate }
-export default { read, write, key, invalidate }
+export { read, write, key, invalidate, serializeQuery }
+export default { read, write, key, invalidate, serializeQuery }

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import merge from 'lodash/merge'
 import isFunction from 'lodash/isFunction'
 
 import request from './request'
+import { serializeQuery } from './cache'
 import { defaults, makeConfig, mergeRequestConfig } from './config'
 
 /**
@@ -103,5 +104,5 @@ function setup (config = {}) {
   return api
 }
 
-export { setup, setupCache }
-export default { setup, setupCache }
+export { setup, setupCache, serializeQuery }
+export default { setup, setupCache, serializeQuery }

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -9,7 +9,7 @@ import MockDate from 'mockdate'
 import localforage from 'localforage'
 import memoryDriver from 'localforage-memoryStorageDriver'
 
-import { setup, setupCache } from 'src/index'
+import { setup, setupCache, serializeQuery } from 'src/index'
 import MemoryStore from 'src/memory'
 
 const REQUEST_TIMEOUT = 10000
@@ -20,6 +20,7 @@ describe('Integration', function () {
   it('Should expose a public API', function () {
     assert.ok(isFunction(setupCache))
     assert.ok(isFunction(setup))
+    assert.ok(isFunction(serializeQuery))
 
     const cache = setupCache()
 


### PR DESCRIPTION
Fixes #66 

```js
import { serializeQuery } from 'axios-cache-adapter'
```