### PR TITLE
Add class transform to babel config

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "license": "MIT",
   "devDependencies": {
     "@babel/core": "^7.1.2",
+    "@babel/plugin-transform-classes": "^7.4.4",
     "@babel/polyfill": "^7.0.0",
     "@babel/preset-env": "^7.1.0",
     "@tusbar/cache-control": "0.3.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -74,6 +74,9 @@ const build = {
             presets: [
               ['@babel/preset-env', {
                 useBuiltIns: 'usage',
+                include: [
+                  '@babel/plugin-transform-classes'
+                ],
                 exclude: [
                   'es6.promise',
                   'web.dom.iterable',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -74,9 +74,6 @@ const build = {
             presets: [
               ['@babel/preset-env', {
                 useBuiltIns: 'usage',
-                include: [
-                  '@babel/plugin-transform-classes'
-                ],
                 exclude: [
                   'es6.promise',
                   'web.dom.iterable',
@@ -87,7 +84,8 @@ const build = {
                   'es6.array.filter'
                 ]
               }]
-            ]
+            ],
+            plugins: ['@babel/plugin-transform-classes']
           }
         }]
       }


### PR DESCRIPTION
Forcing transformation of classes to cater for `@tusbar/cache-control` should be enough for now.

I could not really test it, as I could not build the project in Windows, but it should work.

Resolves #78  (possibly).