### PR TITLE
IE11 bug: axios-cache-adapter breaks the page

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@babel/plugin-transform-classes": "^7.4.4",
     "@babel/polyfill": "^7.0.0",
     "@babel/preset-env": "^7.1.0",
-    "@tusbar/cache-control": "0.3.1",
     "assert": "^1.4.1",
     "babel-loader": "^8.0.4",
     "codecov": "^3.0.0",
@@ -72,6 +71,7 @@
     "webpack-cli": "^3.1.1"
   },
   "dependencies": {
+    "@tusbar/cache-control": "^0.3.1",
     "axios": "^0.18.0",
     "lodash": "^4.17.11"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,8 @@ const dependencies = [
   'lodash/map',
   'lodash/merge',
   'lodash/omit',
-  'axios'
+  'axios',
+  '@tusbar/cache-control'
 ]
 
 dependencies.forEach(dep => {


### PR DESCRIPTION
IE11 bug: axios-cache-adapter doesn't work in IE11 because of "new CacheControl" from @tusbar/cache-control (polyfill is not applied).

Commit defines @tusbar/cache-control as the dependency and adds it to dependencies list in webpack4