### PR TITLE
Update axios-cache-adapter.d.ts

### DIFF
--- a/axios-cache-adapter.d.ts
+++ b/axios-cache-adapter.d.ts
@@ -101,7 +101,7 @@ export interface ISetupCache
 {
 	adapter: AxiosAdapter;
 	config: IAxiosCacheAdapterOptions;
-	store;
+	store: object;
 }
 
 /**


### PR DESCRIPTION
Changes `store`'s type to `object` from implicit `any`.

Fixes this
```
<>/node_modules/axios-cache-adapter/axios-cache-adapter.d.ts
ERROR in <>/node_modules/axios-cache-adapter/axios-cache-adapter.d.ts(104,2):
TS7008: Member 'store' implicitly has an 'any' type.
```