### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ async function configure () {
   await localforage.defineDriver(memoryDriver)
 
   // Create `localforage` instance
-  const store = localforage.createInstance({
+  const forageStore = localforage.createInstance({
     // List of drivers used
     driver: [
       localforage.INDEXEDDB,
@@ -162,7 +162,7 @@ async function configure () {
     // `axios-cache-adapter` options
     cache: {
       maxAge: 15 * 60 * 1000,
-      store // Pass `localforage` store to `axios-cache-adapter`
+      store: forageStore // Pass `localforage` store to `axios-cache-adapter`
     }
   })
 }


### PR DESCRIPTION
Correct the example localforage as cache store in the readme file --- it's missing the `store:` key. Renamed the localforage store instance from `store` to `forageStore` just to provide some visual clarity.