### PR TITLE
move `cache-control-esm` to `dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@babel/core": "^7.1.2",
     "@babel/polyfill": "^7.0.0",
     "@babel/preset-env": "^7.1.0",
-    "cache-control-esm": "1.0.0",
     "assert": "^1.4.1",
     "babel-loader": "^8.0.4",
     "codecov": "^3.0.0",
@@ -73,6 +72,7 @@
   },
   "dependencies": {
     "axios": "^0.18.0",
+    "cache-control-esm": "1.0.0",
     "lodash": "^4.17.11"
   },
   "size-limit": [


### PR DESCRIPTION
...since it is used in src/response.js