### PR TITLE
WIP: Replace expensive lodash calls with native functions

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,6 +1,4 @@
 import axios from 'axios'
-import omit from 'lodash/omit'
-import merge from 'lodash/merge'
 import isFunction from 'lodash/isFunction'
 
 import request from './request'
@@ -90,16 +88,14 @@ function setupCache (config = {}) {
  * @returns {object} Instance of Axios
  */
 function setup (config = {}) {
-  config = merge({}, defaults.axios, config)
+  config = { ...defaults.axios, ...config }
 
-  const cache = setupCache(config.cache)
-  const axiosConfig = omit(config, ['cache'])
+  const cacher = setupCache(config.cache)
+  const { cache, ...axiosConfig } = config
 
-  const api = axios.create(
-    merge({}, axiosConfig, { adapter: cache.adapter })
-  )
+  const api = axios.create({ ...axiosConfig, adapter: cacher.adapter })
 
-  api.cache = cache.store
+  api.cache = cacher.store
 
   return api
 }

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,6 +1,5 @@
 import isString from 'lodash/isString'
 import isFunction from 'lodash/isFunction'
-import map from 'lodash/map'
 
 import serialize from './serialize'
 
@@ -100,9 +99,7 @@ function serializeQuery (req) {
   // Convert to an instance of URLSearchParams so it get serialized the same way
   if (!isInstanceOfURLSearchParams) {
     params = new URLSearchParams()
-
-    // Using lodash/map even though we don't listen to output so we don't have to bundle lodash/forEach
-    map(req.params, (value, key) => params.append(key, value))
+    req.params.map((value, key) => params.append(key, value))
   }
 
   return `?${params.toString()}`

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,4 @@
 import axios from 'axios'
-import merge from 'lodash/merge'
-import omit from 'lodash/omit'
 
 import MemoryStore from './memory'
 import { key, invalidate } from './cache'
@@ -48,7 +46,7 @@ const disallowedPerRequestKeys = ['limit', 'store', 'adapter', 'uuid', 'acceptSt
  * @return {Object}
  */
 const makeConfig = function (override = {}) {
-  let config = merge({}, defaults.cache, override)
+  let config = { ...defaults.cache, ...override }
 
   // Create a cache key method
   config.key = key(config)
@@ -81,8 +79,8 @@ const makeConfig = function (override = {}) {
  * @return {Object}
  */
 const mergeRequestConfig = function (config, req) {
-  const requestConfig = req.cache
-  const mergedConfig = merge({}, config, omit(requestConfig, disallowedPerRequestKeys))
+  const { disallowedPerRequestKeys, ...requestConfig } = req.cache
+  const mergedConfig = { ...config, ...requestConfig }
 
   if (mergedConfig.debug === true) {
     mergedConfig.debug = debug

--- a/src/exclude.js
+++ b/src/exclude.js
@@ -1,4 +1,3 @@
-import find from 'lodash/find'
 import isEmpty from 'lodash/isEmpty'
 
 function exclude (config = {}, req) {
@@ -22,7 +21,7 @@ function exclude (config = {}, req) {
   }
 
   const paths = exclude.paths || []
-  const found = find(paths, regexp => req.url.match(regexp))
+  const found = paths.find(regexp => req.url.match(regexp))
 
   if (found) {
     debug(`Excluding request by url match ${req.url}`)

--- a/src/memory.js
+++ b/src/memory.js
@@ -1,6 +1,3 @@
-import size from 'lodash/size'
-import map from 'lodash/map'
-
 class MemoryStore {
   constructor () {
     this.store = {}
@@ -27,12 +24,12 @@ class MemoryStore {
   }
 
   async length () {
-    return size(this.store)
+    return Object.keys(this.store).length
   }
 
   iterate (fn) {
     return Promise.all(
-      map(this.store, (value, key) => fn(value, key))
+      this.store.map((value, key) => fn(value, key))
     )
   }
 }

--- a/src/redis.js
+++ b/src/redis.js
@@ -1,10 +1,8 @@
-import map from 'lodash/map'
-import get from 'lodash/get'
 import { promisify } from 'util'
 
 class RedisStore {
   constructor (client, HASH_KEY = 'axios-cache') {
-    if (get(client, 'constructor.name') !== 'RedisClient') {
+    if (client && client.constructor && client.contstructor.name !== 'RedisClient') {
       throw new Error('Not valid redis client')
     }
     this.client = client
@@ -42,7 +40,7 @@ class RedisStore {
   async iterate (fn) {
     const hashData = await this.hgetallAsync(this.HASH_KEY)
     return Promise.all(
-      map(hashData, (value, key) => fn(value, key))
+      hashData.map((value, key) => fn(value, key))
     )
   }
 }

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -1,5 +1,3 @@
-import omit from 'lodash/omit'
-
 function serialize (config, req, res) {
   if (res.data) {
     // FIXME: May be useless as localForage and axios already parse automatically
@@ -10,7 +8,8 @@ function serialize (config, req, res) {
     }
   }
 
-  return omit(res, ['request', 'config'])
+  const { request, config, ...response } = res;
+  return response;
 }
 
 export default serialize

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,0 +1,36 @@
+export function isObject(value) {
+  const type = typeof value
+  return value != null && (type == "object" || type == "function")
+}
+
+export function getTag(value) {
+  if (value == null) {
+    return value === undefined ? "[object Undefined]" : "[object Null]"
+  }
+  return toString.call(value)
+}
+
+export function isFunction(value) {
+  if (!isObject(value)) {
+    return false
+  }
+  
+  const tag = getTag(value)
+  return (
+    tag == "[object Function]" ||
+    tag == "[object AsyncFunction]" ||
+    tag == "[object GeneratorFunction]" ||
+    tag == "[object Proxy]"
+  )
+}
+
+export function isString(value) {
+  const type = typeof value
+  return (
+    type == "string" ||
+    (type == "object" &&
+      value != null &&
+      !Array.isArray(value) &&
+      getTag(value) == "[object String]")
+  )
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,11 +21,6 @@ const dependencies = [
   'lodash/isEmpty',
   'lodash/isString',
   'lodash/isFunction',
-  'lodash/size',
-  'lodash/find',
-  'lodash/map',
-  'lodash/merge',
-  'lodash/omit',
   'axios'
 ]
 


### PR DESCRIPTION
All of the complicated Lodash commands being imported have native ES6 equivalents. So long as Babel is being used to transpile and polyfill, there shouldn't be much of a need for Lodash.

This PR is an example of replacing functions like Map, Merge, Omit, etc. with the native JavaScript equivalents. Interested in your feedback regarding if you might take such a change. I've also included a new `utilities.js` file with the smaller Lodash functions copied from Lodash. If desired, this could completely remove the need to have a Lodash dependency.

My growing sense is that unless you are working on a very large app that can make extensive use of Lodash, it's too expensive to use it. Their function dependency graph is very deep, where each helper function relies on many of their other helper functions. Importing a couple functions will immediately pull in large amounts of the Lodash library.

Currently `Lodash` makes up 35.4% of the `axios-cache-adapter` library. `Axios` accounts for 8.9%. Both of these dependencies can be removed to reduce the bundle size by nearly 44.3%.
https://bundlephobia.com/result?p=axios-cache-adapter@2.4.1

Related issues:
#112, #38 