### PR TITLE
Add nodejs sequelize cache

### DIFF
--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -2,7 +2,7 @@ const Sequelize = require('sequelize');
 
 class SequelizeCache {
   constructor (config = 'sqlite:cache.sqlite') {
-    const sequelize = new Sequelize(config)
+    const sequelize = new Sequelize(config, {logging: false})
 
     this.items = sequelize.define('items', {
       key: Sequelize.STRING,
@@ -19,7 +19,7 @@ class SequelizeCache {
   }
 
   async getItem (key) {
-    const item = await this.items.findOne({where: {key}})
+    const item = await this.items.findOne({ where: {key}})
     return item ? JSON.parse(item.payload) : null
   }
 

--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -15,16 +15,16 @@ class SequelizeCache {
         }
       ]
     });
-    this.store = {}
+    this.items.sync();
   }
 
   async getItem (key) {
-    const item = await this.items.findOne({key}) || null
-    return JSON.parse(item.payload)
+    const item = await this.items.findOne({where: {key}})
+    return item ? JSON.parse(item.payload) : null
   }
 
   async setItem (key, value) {
-    await this.items.create({key, payload: value})
+    await this.items.create({key, payload: JSON.stringify(value)})
     return value
   }
 

--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -1,0 +1,48 @@
+const Sequelize = require('sequelize');
+
+class SequelizeCache {
+  constructor (config = 'sqlite:cache.sqlite') {
+    const sequelize = new Sequelize(config)
+
+    this.items = sequelize.define('items', {
+      key: Sequelize.STRING,
+      payload: Sequelize.STRING,
+      created_at: { type: Sequelize.DATE, defaultValue: Sequelize.NOW }
+    }, {
+      indexes: [
+        {
+          fields: ['key']
+        }
+      ]
+    });
+    this.store = {}
+  }
+
+  async getItem (key) {
+    const item = await this.items.findOne({key}) || null
+    return JSON.parse(item.payload)
+  }
+
+  async setItem (key, value) {
+    await this.items.create({key, payload: value})
+    return value
+  }
+
+  async removeItem (key) {
+    await this.items.destroy({where: {key}})
+  }
+
+  async clear () {
+    await this.items.destroy({ truncate: true })
+  }
+
+  async length () {
+    return await this.items.count();
+  }
+
+  iterate (fn) {
+    return this.items.findAll().then(item => fn(item.key, item.payload))
+  }
+}
+
+module.exports = SequelizeCache


### PR DESCRIPTION
Add the Node.js sequelize SQL cache store.

This helps e.g. for tests to cache huge number of requests in a local sqlite database file.
