### PR TITLE
use babel to handle object rest/spread

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -96,7 +96,7 @@ const build = {
               ['@babel/preset-env', {
                 useBuiltIns: 'usage',
                 exclude: polyfillExclusions,
-                include: ['transform-classes']
+                include: ['transform-classes', 'proposal-object-rest-spread']
               }]
             ]
           }


### PR DESCRIPTION
in the last commit, in https://github.com/RasCarlito/axios-cache-adapter/blob/master/src/serialize.js#L11 
it was changed to `const { request, config: _, ...serialized } = res` instead of using a lodash method.

but in order to not break old browsers (edge, ie11, safari 11, etc https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax), that needs to be transpiled.