### PR TITLE
feat(cache): cache `request.res.responseUrl`

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -24,7 +24,11 @@ async function request (config, req) {
     const res = await read(config, req)
 
     res.config = req
-    res.request = { fromCache: true }
+
+    res.request = {
+      ...res.request,
+      fromCache: true,
+    }
 
     return { config, next: res }
   } catch (err) {

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -9,7 +9,15 @@ function serialize (config, req, res) {
   }
 
   const { request, config: _, ...serialized } = res
-  return serialized
+
+  return {
+    ...serialized,
+    request: {
+      res: {
+        responseUrl: request && request.res && request.res.responseUrl
+      },
+    },
+  }
 }
 
 export default serialize


### PR DESCRIPTION
sometime we need use `responseUrl`, 

for example: use with `jsdom` and `jquery` for get dom prop `href`
