### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ async defaultInvalidate (config, request) {
   const method = request.method.toLowerCase()
 
   if (method !== 'get') {
-    await config.store.removeItem(config.uuid)
+    await config.store.removeItem(config.url)
   }
 }
 ```
@@ -308,7 +308,7 @@ const api = setup({
     // Invalidate only when a specific option is passed through config
     invalidate: async (config, request) => {
       if (request.clearCacheEntry) {
-        await config.store.removeItem(config.uuid)
+        await config.store.removeItem(config.url)
       }
     }
   }


### PR DESCRIPTION
I think these are meant to be `url`. There is no `uuid` property on the config, and the `url` is used for cache keys.