### PR TITLE
fix(cache): include baseURL in cache key

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
   "dependencies": {
     "cache-control-esm": "1.0.0",
     "lodash": "^4.17.11",
-    "md5": "^2.2.1"
+    "md5": "^2.2.1",
+    "whatwg-url": "^7.1.0"
   },
   "peerDependencies": {
     "axios": "0.18.1"

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,6 +1,7 @@
 import isString from 'lodash/isString'
 import isFunction from 'lodash/isFunction'
 import md5 from 'md5'
+import { URL } from 'whatwg-url'
 
 import serialize from './serialize'
 
@@ -70,12 +71,14 @@ function key (config) {
   let cacheKey
   if (isString(config.key)) {
     cacheKey = req => {
-      const key = `${config.key}/${req.url}${serializeQuery(req)}`
+      const url = new URL(req.url, req.baseURL)
+      const key = `${config.key}/${url.href}${serializeQuery(req)}`
       return req.data ? key + md5(req.data) : key
     }
   } else {
     cacheKey = req => {
-      const key = req.url + serializeQuery(req)
+      const url = new URL(req.url, req.baseURL)
+      const key = url.href + serializeQuery(req)
       return req.data ? key + md5(req.data) : key
     }
   }

--- a/test/spec/cache.spec.js
+++ b/test/spec/cache.spec.js
@@ -136,11 +136,11 @@ describe('Cache store', () => {
     let cacheKey = cache.key({ key: 'my-key' })
 
     assert.ok(isFunction(cacheKey))
-    assert.equal(cacheKey({ url: 'url' }), 'my-key/url')
+    assert.equal(cacheKey({ url: 'https://httpbin.org' }), 'my-key/https://httpbin.org/')
 
     cacheKey = cache.key({})
 
     assert.ok(isFunction(cacheKey))
-    assert.equal(cacheKey({ url: 'url' }), 'url')
+    assert.equal(cacheKey({ url: 'https://httpbin.org' }), 'https://httpbin.org/')
   })
 })

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -132,6 +132,30 @@ describe('Integration', function () {
     assert.ok(response.request.fromCache)
   })
 
+  it("Should not cache requests with same url but different baseURL", async () => {
+    const api = setup()
+
+    // https://httpbin.org/anything
+    const response = await api.get("anything", {
+      baseURL: "https://httpbin.org/",
+      cache: {
+        maxAge: 15 * 1000
+      }
+    })
+
+    assert.notEqual(response.request.fromCache, true)
+
+    // https://httpbin.org/anything/anything
+    const response2 = await api.get("anything", {
+      baseURL: "https://httpbin.org/anything/",
+      cache: {
+        maxAge: 15 * 1000
+      }
+    })
+
+    assert.notEqual(response2.request.fromCache, true)
+  })
+
   it('Should cache GET requests with params even though URLSearchParams does not exist', async () => {
     const URLSearchParamsBackup = URLSearchParams
     window.URLSearchParams = undefined

--- a/test/spec/request.spec.js
+++ b/test/spec/request.spec.js
@@ -27,7 +27,7 @@ describe('Request', () => {
     }
 
     req = {
-      url: 'url',
+      url: 'https://httpbin.org/',
       method: 'GET'
     }
 
@@ -62,7 +62,7 @@ describe('Request', () => {
   it('Should notify an exclusion and clear cache for http methods not one of get, post, patch, put or delete', async () => {
     req.method = 'OPTIONS'
 
-    await store.setItem('url', res)
+    await store.setItem('https://httpbin.org/', res)
 
     const result = await request(config, req)
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

When using `axios@0.19.2` the `req.url` property doesn't include the `baseURL`. This resulted in requests with the same `path` but a different `baseURL` to be cached with the same key.

**How did you fix it?**

Used `whatwg-url` to combine `req.url` and a potential `req.baseURL` into a full url