### PR TITLE
handle as no-cache when a server responds no `cache-control` in headers

### DIFF
--- a/src/response.js
+++ b/src/response.js
@@ -23,6 +23,8 @@ async function response (config, req, res) {
       }
     } else if (headers.expires) { // Else try reading `expires` header
       config.expires = new Date(headers.expires).getTime()
+    } else {
+      config.expires = new Date().getTime()
     }
   }
 

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -414,6 +414,25 @@ describe('Integration', function () {
     MockDate.reset()
   })
 
+  it("when no cache-control header", async () => {
+    MockDate.set(10000000)
+
+    const api = setup({
+      baseURL: "https://httpbin.org",
+      cache: { readHeaders: true }
+    })
+
+    const response = await api.get("/cache")
+
+    assert.ok(!response.request.fromCache)
+
+    const item = await api.cache.getItem("https://httpbin.org/cache/")
+
+    assert.equal(item.expires, 1000000)
+
+    MockDate.reset()
+  })
+
   it('Should exclude from cache when reading no-cache or must-revalidate from cache-control', async () => {
     const baseURL = 'https://httpbin.org'
     const noCacheRoute = '/response-headers?cache-control=no-cache'


### PR DESCRIPTION
This addresses issue https://github.com/RasCarlito/axios-cache-adapter/issues/168