### PR TITLE
chore(node): drop node 6 and 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 node_js:
-  - "6"
-  - "8"
   - "10"
+  - "12"
 
 addons:
   apt:


### PR DESCRIPTION
Stop testing axios-cache-adapter with node v6 and v8 with travis
Add node v12