### PR TITLE
better typing for `limit` option field

### DIFF
--- a/axios-cache-adapter.d.ts
+++ b/axios-cache-adapter.d.ts
@@ -34,7 +34,7 @@ export interface IAxiosCacheAdapterOptions
 	 * {Number} Maximum number of cached request (last in, first out queue system),
 	 * defaults to `false` for no limit. *Cannot be overridden per request*
 	 */
-	limit?: boolean;
+	limit?: false | number;
 	/**
 	 * {Object} An instance of localforage, defaults to a custom in memory store.
 	 * *Cannot be overridden per request*


### PR DESCRIPTION
should accept `false` or a number