### PR TITLE
Methods Array should be optional

### DIFF
--- a/axios-cache-adapter.d.ts
+++ b/axios-cache-adapter.d.ts
@@ -74,7 +74,7 @@ export interface IAxiosCacheAdapterOptions
      *
      * Note: the HEAD method is always excluded (hard coded).
      */
-    methods: Array;
+    methods?: Array;
 	};
 	/**
 	 * {Boolean} Clear cached item when it is stale.


### PR DESCRIPTION
Looks like the code already assumes that the new methods array is optional, but the typing considers it required.

For backward compatibility with old config settings, this should be optional.