### PR TITLE
fix: Change `methods` type to array of predefined strings

### DIFF
--- a/axios-cache-adapter.d.ts
+++ b/axios-cache-adapter.d.ts
@@ -74,7 +74,7 @@ export interface IAxiosCacheAdapterOptions
      *
      * Note: the HEAD method is always excluded (hard coded).
      */
-    methods?: Array;
+    methods?: ('get' | 'post' | 'patch' | 'put' | 'delete')[];
 	};
 	/**
 	 * {Boolean} Clear cached item when it is stale.


### PR DESCRIPTION
I have my CI failing since the 2.7.1 release about the type of [methods](https://github.com/RasCarlito/axios-cache-adapter/blob/2573d6e46198610a39be54d7484ca19c40098c37/axios-cache-adapter.d.ts#L77).
```
node_modules/axios-cache-adapter/axios-cache-adapter.d.ts(77,15): error TS2314: Generic type 'Array<T>' requires 1 type argument(s).
```
At the very least the definition should be changed to `Array<string>` however I propose changing the type to an array of predefined strings.
This solves the compilation issue as well as improves developer experience because the user now knows what the valid options are.