### PR TITLE
fix(limit): invalidate oldest cache when reaching limit size

### DIFF
--- a/src/memory.js
+++ b/src/memory.js
@@ -30,7 +30,10 @@ class MemoryStore {
   }
 
   iterate (fn) {
-    return Promise.all(mapObject(this.store, fn))
+    const wrapped = (value, key) => {
+      return fn(JSON.parse(value), key)
+    }
+    return Promise.all(mapObject(this.store, wrapped))
   }
 }
 

--- a/src/redis.js
+++ b/src/redis.js
@@ -49,8 +49,11 @@ class RedisStore {
   }
 
   async iterate (fn) {
+    const wrapped = (value, key) => {
+      return fn(JSON.parse(value), key)
+    }
     const hashData = await this.hgetallAsync(this.HASH_KEY)
-    return Promise.all(mapObject(hashData, fn))
+    return Promise.all(mapObject(hashData, wrapped))
   }
 }
 

--- a/test/spec/limit.spec.js
+++ b/test/spec/limit.spec.js
@@ -27,16 +27,19 @@ describe('Limit', () => {
 
       await store.setItem('test', { expires: now })
       await store.setItem('retest', { expires: now + (60 * 1000) })
+      await store.setItem('oldest', { expires: now - (60 * 1000) })
 
       let length = await store.length()
 
-      assert.strictEqual(length, 2)
+      assert.strictEqual(length, 3)
 
       await limit(config)
 
       length = await store.length()
 
-      assert.strictEqual(length, 1)
+      assert.strictEqual(length, 2)
+      assert(await store.getItem('test'))
+      assert(await store.getItem('retest'))
     })
   })
 })


### PR DESCRIPTION
When the number of cached requests reaches the configured `limit`, the oldest cached item should be removed from the store.

 #247