### PR TITLE
nullcheck req.url when doing exclude checks

### DIFF
--- a/src/exclude.js
+++ b/src/exclude.js
@@ -28,7 +28,7 @@ function exclude (config = {}, req) {
   }
 
   const paths = exclude.paths || []
-  const found = paths.some(regexp => req.url.match(regexp))
+  const found = paths.some(regexp => req.url && req.url.match(regexp))
 
   if (found) {
     debug(`Excluding request by url match ${req.url}`)


### PR DESCRIPTION
Under certain circumstances, the request.url can be undefined which causes exclude checks to throw an error and crash.

If I understand correctly, this only happens with certain (not very popular) browsers or when doing request blocking from dev tools. Nonetheless, a simple nullcheck solves the situation.